### PR TITLE
QuoteGarden APIを新しいドメインに移行

### DIFF
--- a/src/config/ky.ts
+++ b/src/config/ky.ts
@@ -1,6 +1,6 @@
 import { Options } from 'ky';
 
 export const DEFAULT_API_OPTIONS: Options = {
-  prefixUrl: 'https://quote-garden.herokuapp.com/api/v3',
+  prefixUrl: 'https://quote-garden.onrender.com/api/v3',
   retry: 0,
 };


### PR DESCRIPTION
## Issue番号
closes #13 

## 対応内容
- QuoteGarden API のドメインを Heroku から Render のものに移行
