### PR TITLE
APIは自分でホスティングしたものを使うようにした

### DIFF
--- a/src/config/ky.ts
+++ b/src/config/ky.ts
@@ -7,7 +7,7 @@ const api = ky.create({
 });
 
 const apiServer = kyServer.create({
-  prefixUrl: 'https://quoteslate.vercel.app/api',
+  prefixUrl: 'https://quote-slate-theta.vercel.app/api',
   retry: 0,
 });
 


### PR DESCRIPTION
## Issue 番号
<!-- ※マージとともクローズの場合は closes をつける -->
closes #25

## 対応内容
- 使用する API を自分でホスティングしているものに差し替え

○○-○○-○○-hitomi-yoshikawas-projects.vercel.app はプレビュー環境扱いになるみたいで、 保護機能にひっかかるので、本番環境用URLのほうを使っている。